### PR TITLE
Feature/update gradle version 6

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -44,6 +44,17 @@ services:
           # The command cp -t used below does not work without coreutils
         - UNMAZEDBOOT_INTERNAL_DEPENDENCIES=apk add coreutils --no-cache
 
+  builder-gradle6.7.0-jdk8-hotspot:
+    image: marcellodesales/unmazedboot-builder-gradle:6.7.0-jdk8-hotspot${UNMAZEDBOOT_BUILDER_GRADLE_VERSION}
+    build:
+      context: builder
+      dockerfile: gradle.Dockerfile
+      args:
+        - UNMAZEDBOOT_INTERNAL_BASE_IMAGE=gradle:6.7.0-jdk8-hotspot
+          # https://github.com/passbolt/passbolt_docker/issues/75#issuecomment-439629647
+          # The command cp -t used below does not work without coreutils
+        - UNMAZEDBOOT_INTERNAL_DEPENDENCIES=echo none
+
   builder-maven3.6.0-jdk8-slim:
     image: intuit/unmazedboot-builder-maven:3.6.0-jdk8-slim${UNMAZEDBOOT_BUILDER_MAVEN_VERSION}
     build:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -55,6 +55,17 @@ services:
           # The command cp -t used below does not work without coreutils
         - UNMAZEDBOOT_INTERNAL_DEPENDENCIES=echo none
 
+  builder-gradle6.7.1-jdk15-hotspot:
+    image: marcellodesales/unmazedboot-builder-gradle:6.7.1-jdk15-hotspot${UNMAZEDBOOT_BUILDER_GRADLE_VERSION}
+    build:
+      context: builder
+      dockerfile: gradle.Dockerfile
+      args:
+        - UNMAZEDBOOT_INTERNAL_BASE_IMAGE=gradle:6.7.1-jdk15-hotspot
+          # https://github.com/passbolt/passbolt_docker/issues/75#issuecomment-439629647
+          # The command cp -t used below does not work without coreutils
+        - UNMAZEDBOOT_INTERNAL_DEPENDENCIES=echo none
+
   builder-maven3.6.0-jdk8-slim:
     image: intuit/unmazedboot-builder-maven:3.6.0-jdk8-slim${UNMAZEDBOOT_BUILDER_MAVEN_VERSION}
     build:


### PR DESCRIPTION
### Requirements

Update current version of `Unmazedboot@0.5.0` builders

* Gradle Version to `6.7.0 - JDK 8`
  * marcellodesales/unmazedboot-builder-gradle:6.7.0-jdk8-hotspot-0.5.0
* Gradle Version to `6.7.1 - JDK 15`
  * marcellodesales/unmazedboot-builder-gradle:6.7.1-jdk15-hotspot-0.5.0

Just explain your new change

Needed for new apps

# Images Pushed

```console
$ docker-compose build builder-gradle6.7.1-jdk15-hotspot
Building builder-gradle6.7.1-jdk15-hotspot
Step 1/24 : ARG UNMAZEDBOOT_INTERNAL_BASE_IMAGE
Step 2/24 : FROM ${UNMAZEDBOOT_INTERNAL_BASE_IMAGE}
6.7.1-jdk15-hotspot: Pulling from library/gradle
6a5697faee43: Pull complete
ba13d3bc422b: Pull complete
a254829d9e55: Pull complete
03adaffd7e57: Pull complete
dd2a657a63fc: Pull complete
363e5558910f: Pull complete
c56e49c3b954: Pull complete
4fbf4e1e944b: Pull complete
Digest: sha256:46702f4af7a869cc0c0f0e9071d7eb75a52c4968657bf3bbc95c08308d6ac8e5
Status: Downloaded newer image for gradle:6.7.1-jdk15-hotspot
 ---> da3dd36eeed7
Step 3/24 : USER root
 ---> Running in 46dae3748420
Removing intermediate container 46dae3748420
 ---> d2b756fac3bc
Step 4/24 : ARG UNMAZEDBOOT_INTERNAL_DEPENDENCIES
 ---> Running in 016f648da342
Removing intermediate container 016f648da342
 ---> b10eeea3bfc4
Step 5/24 : RUN sh -c "${UNMAZEDBOOT_INTERNAL_DEPENDENCIES}"
 ---> Running in 5ccac2b6a73a
none
Removing intermediate container 5ccac2b6a73a
 ---> 40fdf0d35ad0
Step 6/24 : ONBUILD ARG BUILDER_BINARY_DEPENDENCIES
 ---> Running in 4065c243393e
Removing intermediate container 4065c243393e
 ---> d38a1d26f591
Step 7/24 : ONBUILD RUN sh -c "${BUILDER_BINARY_DEPENDENCIES:-echo installing-no-builder-dependencies}"
 ---> Running in e0a9e6df9d27
Removing intermediate container e0a9e6df9d27
 ---> 1df6050c8c4b
Step 8/24 : ONBUILD ARG UNMAZEDBOOT_BUILDER_GRADLE_BUILD_CMD
 ---> Running in a0fa796714d9
Removing intermediate container a0fa796714d9
 ---> 4485787f3963
Step 9/24 : ONBUILD ARG UNMAZEDBOOT_BUILDER_PACKAGE_EXTENSION
 ---> Running in 544acbf786b7
Removing intermediate container 544acbf786b7
 ---> b4f4b71ee9d8
Step 10/24 : ONBUILD ENV UNMAZEDBOOT_BUILDER_PACKAGE_EXTENSION=${UNMAZEDBOOT_BUILDER_PACKAGE_EXTENSION}
 ---> Running in 1a1cf0491fed
Removing intermediate container 1a1cf0491fed
 ---> 6d45cd17e7f4
Step 11/24 : ONBUILD ARG UNMAZEDBOOT_BUILDER_DIR
 ---> Running in 5af400357aca
Removing intermediate container 5af400357aca
 ---> fd8bb32e8656
Step 12/24 : ONBUILD ENV UNMAZEDBOOT_BUILDER_DIR=${UNMAZEDBOOT_BUILDER_DIR}
 ---> Running in ac224daaf407
Removing intermediate container ac224daaf407
 ---> 656984fd9d28
Step 13/24 : WORKDIR /app/
 ---> Running in bfea6e8ca6fc
Removing intermediate container bfea6e8ca6fc
 ---> 61169738eec8
Step 14/24 : ONBUILD COPY ./build.gradle build.gradle
 ---> Running in b361fc4bb5eb
Removing intermediate container b361fc4bb5eb
 ---> b2261314b14d
Step 15/24 : ONBUILD COPY ./settings.gradle settings.gradle
 ---> Running in 69754c691b7e
Removing intermediate container 69754c691b7e
 ---> 53a0bbdb7ba8
Step 16/24 : ONBUILD COPY ./src src/
 ---> Running in 54d1779195eb
Removing intermediate container 54d1779195eb
 ---> ae45fc424b75
Step 17/24 : ONBUILD RUN echo "Executing UNMAZEDBOOT_BUILDER_GRADLE_BUILD_CMD='${UNMAZEDBOOT_BUILDER_GRADLE_BUILD_CMD}'"
 ---> Running in c8c4711e9caf
Removing intermediate container c8c4711e9caf
 ---> 7ea21705e18d
Step 18/24 : ONBUILD RUN ${UNMAZEDBOOT_BUILDER_GRADLE_BUILD_CMD}
 ---> Running in ba65d702ea04
Removing intermediate container ba65d702ea04
 ---> 19cf5ef5abed
Step 19/24 : ONBUILD RUN echo "Built artifacts at /app/${UNMAZEDBOOT_BUILDER_DIR} and looking for package .${UNMAZEDBOOT_BUILDER_PACKAGE_EXTENSION}"
 ---> Running in e34bfb3822bc
Removing intermediate container e34bfb3822bc
 ---> a2669183ddc5
Step 20/24 : ONBUILD RUN find . -name "/app/${UNMAZEDBOOT_BUILDER_DIR}/*.${UNMAZEDBOOT_BUILDER_PACKAGE_EXTENSION}"
 ---> Running in 3e313a6a1c66
Removing intermediate container 3e313a6a1c66
 ---> 0b72ce1d114d
Step 21/24 : ONBUILD RUN echo "Renaming the executable ${UNMAZEDBOOT_BUILDER_PACKAGE_EXTENSION} to the runtime dir"
 ---> Running in 0fc4ce93f078
Removing intermediate container 0fc4ce93f078
 ---> 64fb26425241
Step 22/24 : ONBUILD RUN mkdir /runtime/ &&             find /app/${UNMAZEDBOOT_BUILDER_DIR} -name "*.${UNMAZEDBOOT_BUILDER_PACKAGE_EXTENSION}" ! -name "*sources*" ! -name "*javadoc*" -exec cp -t /runtime {} + &&             mv /runtime/*.${UNMAZEDBOOT_BUILDER_PACKAGE_EXTENSION} /runtime/server.jar
 ---> Running in 7733fa4fcbe1
Removing intermediate container 7733fa4fcbe1
 ---> 84adce4c5545
Step 23/24 : ONBUILD RUN echo "Contents for built /runtime/server.jar"
 ---> Running in 852b93e6f324
Removing intermediate container 852b93e6f324
 ---> 364c7fbc2217
Step 24/24 : ONBUILD RUN echo "jar -tf /runtime/server.jar"
 ---> Running in b288a07e481c
Removing intermediate container b288a07e481c
 ---> c5db76b26eea

Successfully built c5db76b26eea
Successfully tagged marcellodesales/unmazedboot-builder-gradle:6.7.1-jdk15-hotspot-0.5.0
```