### PR TITLE
:sparkles: :whale: :penguin: :coffee: Add linker jdk15 on alpine 3.12

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -138,6 +138,14 @@ services:
         - UNMAZEDBOOT_INTERNAL_BASE_IMAGE=alpine:3.8
         - UNMAZEDBOOT_INTERNAL_DEPENDENCIES=wget https://download.java.net/openjdk/jdk11/ri/openjdk-11+28_linux-x64_bin.tar.gz && tar -xvzf openjdk-11\+28_linux-x64_bin.tar.gz && ln -s jdk-11 jdk && rm -f openjdk-11\+28_linux-x64_bin.tar.gz
 
+  linker-jdk15-alpine:
+    image: marcellodesales/unmazedboot-linker:jdk15-alpine${UNMAZEDBOOT_LINKER_VERSION}
+    build:
+      context: linker
+      args:
+        - UNMAZEDBOOT_INTERNAL_BASE_IMAGE=openjdk:15-jdk-alpine3.12
+        - UNMAZEDBOOT_INTERNAL_DEPENDENCIES=echo none
+
   # https://github.com/docker-library/openjdk/issues/217#issuecomment-436275472
   # Debian generates large libjvm and can be decreased
   linker-jdk11-debian:


### PR DESCRIPTION
### Requirements

* Add Linker JDK15 on Alpine 3.12

### Description of the Change

* Just a new linker

### Benefits

* Only if desired to have custom JDKs on Java 15


```console
$ docker-compose push linker-jdk15-alpine
Pushing linker-jdk15-alpine (marcellodesales/unmazedboot-linker:jdk15-alpine-0.5.0)...
The push refers to repository [docker.io/marcellodesales/unmazedboot-linker]
ca35920ce48a: Mounted from library/openjdk
a9711b2e31f2: Mounted from library/openjdk
50644c29ef5a: Mounted from marcellodesales/java-junit-xml-merger
jdk15-alpine-0.5.0: digest: sha256:241192b28e5a59a806dd25af79e0812964c1524e72b8b28341e438d8ecb9a82f size: 951
```